### PR TITLE
use scikit-image to instead skimage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ onnx_tf==1.6.0
 scikit_image==0.16.2
 wget==3.2
 Pillow==8.0.1
-skimage==0.0
+scikit-image


### PR DESCRIPTION
When use pip install -r requirements.txt 
scikit-image can work but not skimage. 
(I use Python 3.7 environment on Mac OS X ) 